### PR TITLE
fix #122: Missed ones from PR #140

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1247,24 +1247,39 @@ class rendering_config() {
 
 ### Element Mix Config Syntax and Semantics ### {#syntax-element-mix-config}
 
-ISSUE: Need to review the mix mechanisms.
-
-[=element_mix_config()=] provides a gain value to be applied to the audio element.
+[=element_mix_config()=] provides a gain value to be applied to the rendered audio element signal.
 
 <b>Syntax</b>
 
 ```
 class element_mix_config() {
-  signed int (16) mix_gain;
+  MixGainParamDefinition mix_gain;
 }
 ```
 
 <b>Semantics</b>
 
-<dfn noexport>mix_gain</dfn> is a value in dBs. For mixing of the audio element, this gain shall be applied to all of channels of the audio element. 
+<dfn noexport>mix_gain</dfn> provides the parameter definition for the gain value that is applied to all channels of the rendered audio element signal. The parameter definition is provided by MixGainParamDefinition() and the corresponding parameter data to be provided in parameter blocks is specified in mix_gain_parameter_data().
 
-It shall be stored in a 16-bit, signed, two’s complement fixed-point value with 8 fractional bits (i.e. Q7.8 in [[!Q-Format]]).
+#### Mix Gain Parameter Definition and Data Syntax and Semantics #### {#syntax-mix-gain-param}
 
+<b>Syntax</b>
+
+```
+class MixGainParamDefinition extends ParamDefinition() {
+  signed int (16) default_mix_gain;
+}
+
+class mix_gain_parameter_data(animation_type) {
+  AnimatedParameterData<signed int (16)> param_data;
+}
+```
+
+<b>Semantics</b>
+
+<dfn noexport>default_mix_gain</dfn> shall specify the default mix gain value to apply when there are no mix gain parameter blocks provided. This value is expressed in dB and shall be applied to all channels in the rendered audio element. It is stored as a 16-bit, signed, two's complement fixed-point value with 8 fractional bits (i.e. Q7.8 in [[!Q-Format]]).
+
+<dfn noexport>param_data</dfn> shall use the AnimatedParameterData function template. Each of the values defined within this instance (start_point_value, end_point_value and control_point_value) shall be expressed in dB and shall be applied to all channels in the rendered audio element. They are stored as 16-bit, signed, two's complement fixed-point values with 8 fractional bits (i.e. Q7.8 in [[!Q-Format]]).
 
 ### Mix Loudness Info Syntax and Semantics ### {#syntax-mix-loudness-info}
 


### PR DESCRIPTION
More updates for Element Mix Config which has been missed from PR #140.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iac/pull/166.html" title="Last updated on Nov 4, 2022, 7:46 AM UTC (4634e56)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/AOMediaCodec/iac/166/5bc78e5...4634e56.html" title="Last updated on Nov 4, 2022, 7:46 AM UTC (4634e56)">Diff</a>